### PR TITLE
[Feat] #32 - 로그인 성공 & 실패 동작 구현

### DIFF
--- a/every-time-iOS/every-time-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/every-time-iOS/every-time-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -189,13 +189,20 @@ extension LoginViewController {
     // MARK: - @objc Methods
     
     @objc private func loginButtonDidTap() {
-        idTextField.resignFirstResponder()
-        passwordTextField.resignFirstResponder()
-        setOriginalLoginStackAnimation()
-        let alert = UIAlertController(title: "올바른 정보를 입력해주세요.\nPC에서는 정상적으로 로그인이 되지만 앱에서 로그인이 되지 않을 경우,\n[everytimekr.help@gmail.com] 메일로 아이디와 스크린샷을 보내주시기 바랍니다.", message: nil, preferredStyle: .alert)
-        let closeButton = UIAlertAction(title: "닫기", style: .cancel)
-        alert.addAction(closeButton)
-        present(alert, animated: true)
+        // 실패 시
+//        idTextField.resignFirstResponder()
+//        passwordTextField.resignFirstResponder()
+//        setOriginalLoginStackAnimation()
+//        let alert = UIAlertController(title: "올바른 정보를 입력해주세요.\nPC에서는 정상적으로 로그인이 되지만 앱에서 로그인이 되지 않을 경우,\n[everytimekr.help@gmail.com] 메일로 아이디와 스크린샷을 보내주시기 바랍니다.", message: nil, preferredStyle: .alert)
+//        let closeButton = UIAlertAction(title: "닫기", style: .cancel)
+//        alert.addAction(closeButton)
+//        present(alert, animated: true)
+        
+        // 성공 시
+        let tabBar = EverytimeTabBarController()
+        tabBar.modalTransitionStyle = .crossDissolve
+        tabBar.modalPresentationStyle = .overFullScreen
+        present(tabBar, animated: true)
     }
     
     @objc private func findAccountButtonDidTap() {

--- a/every-time-iOS/every-time-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/every-time-iOS/every-time-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -165,6 +165,16 @@ extension LoginViewController {
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         view.endEditing(true)
+        setOriginalLoginStackAnimation()
+    }
+    
+    private func setAddTarget() {
+        loginButton.addTarget(self, action: #selector(loginButtonDidTap), for: .touchUpInside)
+        findAccountButton.addTarget(self, action: #selector(findAccountButtonDidTap), for: .touchUpInside)
+        signupButton.addTarget(self, action: #selector(signupButtonDidTap), for: .touchUpInside)
+    }
+    
+    private func setOriginalLoginStackAnimation() {
         everyTimeImageView.isHidden = false
         descriptionLabel.isHidden = false
         everyTimeLabel.isHidden = false
@@ -176,12 +186,17 @@ extension LoginViewController {
         }
     }
     
-    private func setAddTarget() {
-        findAccountButton.addTarget(self, action: #selector(findAccountButtonDidTap), for: .touchUpInside)
-        signupButton.addTarget(self, action: #selector(signupButtonDidTap), for: .touchUpInside)
-    }
-    
     // MARK: - @objc Methods
+    
+    @objc private func loginButtonDidTap() {
+        idTextField.resignFirstResponder()
+        passwordTextField.resignFirstResponder()
+        setOriginalLoginStackAnimation()
+        let alert = UIAlertController(title: "올바른 정보를 입력해주세요.\nPC에서는 정상적으로 로그인이 되지만 앱에서 로그인이 되지 않을 경우,\n[everytimekr.help@gmail.com] 메일로 아이디와 스크린샷을 보내주시기 바랍니다.", message: nil, preferredStyle: .alert)
+        let closeButton = UIAlertAction(title: "닫기", style: .cancel)
+        alert.addAction(closeButton)
+        present(alert, animated: true)
+    }
     
     @objc private func findAccountButtonDidTap() {
         print("아이디/비밀번호 찾기")
@@ -200,7 +215,7 @@ extension LoginViewController: UITextFieldDelegate {
         everyTimeImageView.isHidden = true
         descriptionLabel.isHidden = true
         everyTimeLabel.isHidden = true
-        
+
         UIView.animate(withDuration: 0.25) {
             self.loginStackView.snp.updateConstraints {
                 $0.top.equalTo(self.everyTimeLabel.snp.bottom).offset(-100)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#32

## ✏️ 작업한 내용

<img width="303" alt="스크린샷 2023-03-05 오후 1 21 48" src="https://user-images.githubusercontent.com/108191001/222943275-f8571cf4-0c07-4887-9715-cc8db5bdb24f.png">

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
로그인 성공으로 임시 설정

## 📮 관련 이슈
- Resolved: #32
